### PR TITLE
Removed "protip"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ Or edit `composer.json` and add:
 }
 ```
 
-**Protip:** you should browse the
-[`toin0u/digitalocean`](https://packagist.org/packages/toin0u/digitalocean)
-page to choose a stable version to use, avoid the `@stable` meta constraint.
-
 And install dependencies:
 
 ```bash


### PR DESCRIPTION
That's a bad practice. If you want to lock dependencies at a specific version, use a composer.lock file. Otherwise, you should use a "version constraint" rather than selecting a specific version.
